### PR TITLE
Fixes for Django 1.9

### DIFF
--- a/quicklinks/lib/flexible_json.py
+++ b/quicklinks/lib/flexible_json.py
@@ -229,7 +229,7 @@ class JSONSerializer():
 #method to quickly implement the class above
 def json_response_from(response,**options):
     jsonSerializer = JSONSerializer()
-    return HttpResponse(jsonSerializer.serialize(response, use_natural_keys=True,**options), mimetype='application/json')
+    return HttpResponse(jsonSerializer.serialize(response, use_natural_keys=True,**options), content_type='application/json')
 
 
 #example use

--- a/quicklinks/models.py
+++ b/quicklinks/models.py
@@ -16,7 +16,7 @@ class QuickLinkGroup(Sortable):
     order_int = models.IntegerField()
 
     def groups_list(self):
-        group_list = QuickLinkGroup.objects.all().select_related('group_set').order_by('id').values('title', 'group__title', 'group__url')
+        group_list = QuickLinkGroup.objects.all().order_by('id').values('title', 'group__title', 'group__url')
         return group_list
 
 

--- a/quicklinks/views.py
+++ b/quicklinks/views.py
@@ -12,7 +12,7 @@ from django.template import Context, Template
 def indexAlt(request):
 
     listed_groups = QuickLinkGroup.objects.all().order_by('id')#.values('title', 'group__title', 'group__url')
-    listed_links = QuickLink.objects.all().select_related('quicklinkgroup_id')
+    listed_links = QuickLink.objects.all().select_related('quicklinkgroup__id')
     #template = loader.get_template("index.html")
 
     context = {
@@ -29,6 +29,6 @@ def home(request):
 
 
 def links(request):
-    link_groups = QuickLinkGroup.objects.all().select_related('group_set').order_by('id')#gets list of objects
+    link_groups = QuickLinkGroup.objects.all().order_by('id')#gets list of objects
     response = link_groups
     return json_response_from(response, related=['group'], ignored = ['quicklinkgroup', 'quicklinkgroup_id'])


### PR DESCRIPTION
- Removed broken select_relateds that did nothing, which now raise errors in Django 1.9
- Return HttpResponse with content_type not mimetype
- Use dunderscore for select_related("quicklinkgroup__id") not single underscore
